### PR TITLE
Add tests in regard to dots in property names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mappet",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/mappet.spec.ts
+++ b/src/mappet.spec.ts
@@ -43,7 +43,7 @@ describe("mappet", () => {
   });
 
   it("allows for omitting an entry with include", () => {
-    const notNull = (v: any) => v === null ? false : true;
+    const notNull = (v: any) => v !== null;
     const schema = {
       firstName: { path: "first_name", include: notNull },
       lastName: { path: "last_name", include: notNull },

--- a/src/mappet.spec.ts
+++ b/src/mappet.spec.ts
@@ -206,4 +206,37 @@ describe("mappet", () => {
     expect(actual.last_name).toEqual("ZALECKI");
     expect(actual.email).toEqual("example@michalzalecki.com");
   });
+
+  it("behaves like lodash's get in regard to dots in property names", () => {
+    const schema = {
+      ab: "a.b",
+      cde: "c.d.e",
+      cxz: "c.y.z",
+    };
+    const mapper = mappet(schema);
+
+    const source = {
+      "a.b": 1,
+      "a": {
+        b: 2,
+      },
+      "c": {
+        "d": {
+          e: 3,
+        },
+        /**
+         * https://github.com/lodash/lodash/issues/1637#issuecomment-156258271
+         *
+         * To support this case it will be required to change and support `type Path = string | string[]`
+         * Example `cxz: { path: ["c", "y.z"], modifier: (f:any) => f },` and/or make `modifier` optional.
+         */
+        "d.e": 4,
+        "y.z": "You cannot get this and 'd.e'",
+      },
+    };
+    const actual = mapper(source);
+    expect(actual.ab).toEqual(1);
+    expect(actual.cde).toEqual(3);
+    expect(actual.cxz).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Promised test. 

I would like to write code to support this case:
```javascript
const schema = {
  abc: { path: ["a", "b.c"] },
};
const source = {
  "a": {
    "b.c": "value",
  },
};
```
Sounds like minor update (API changes but no breaking changes).