### PR TITLE
Support path array

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mappet",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/mappet.spec.ts
+++ b/src/mappet.spec.ts
@@ -43,7 +43,7 @@ describe("mappet", () => {
   });
 
   it("allows for omitting an entry with include", () => {
-    const notNull = (v: any) => v === null ? false : true;
+    const notNull = (v: any) => v !== null;
     const schema = {
       firstName: { path: "first_name", include: notNull },
       lastName: { path: "last_name", include: notNull },

--- a/src/mappet.spec.ts
+++ b/src/mappet.spec.ts
@@ -206,4 +206,37 @@ describe("mappet", () => {
     expect(actual.last_name).toEqual("ZALECKI");
     expect(actual.email).toEqual("example@michalzalecki.com");
   });
+
+  it("behaves like lodash's get in regard to dots in property names", () => {
+    const schema = {
+      ab: "a.b",
+      cde: "c.d.e",
+      cxz: "c.y.z",
+    };
+    const mapper = mappet(schema);
+
+    const source = {
+      "a.b": 1,
+      "a": {
+        b: 2,
+      },
+      "c": {
+        "d": {
+          e: 3,
+        },
+        /**
+         * https://github.com/lodash/lodash/issues/1637#issuecomment-156258271
+         *
+         * To support this case it will be required to change and support `type Path = string | string[]`
+         * Example `cxz: { path: ["c", "y.z"], modifier: (f:any) => f },` and/or make `modifier` optional.
+         */
+        "d.e": 4,
+        "y.z": "You cannot get this and 'd.e'",
+      },
+    };
+    const actual = mapper(source);
+    expect(actual.ab).toEqual(1);
+    expect(actual.cde).toEqual(3);
+    expect(actual.cxz).toBeUndefined();
+  });
 });

--- a/src/mappet.ts
+++ b/src/mappet.ts
@@ -8,11 +8,12 @@ type Result<T> = {
   [K in keyof T]: any
 };
 
-type Path = string;
+type Path = string | string[];
 type Modifier = (value: any, source: any) => any;
 type Include = (value: any, source: any) => boolean;
+type ComplexSchemaEntry = { path: Path, modifier?: Modifier, include?: Include };
 
-export type SchemaEntry = Path | { path: Path, modifier?: Modifier, include?: Include };
+export type SchemaEntry = Path | ComplexSchemaEntry;
 
 type Schema = {
   [key: string]: SchemaEntry,
@@ -57,6 +58,10 @@ function always(_val: any) {
   return true;
 }
 
+function hasPathOnly(schemaEntry: SchemaEntry) {
+  return typeof schemaEntry === "string" || Array.isArray(schemaEntry);
+}
+
 /**
  * Factory for creating mappers
  *
@@ -67,21 +72,21 @@ function always(_val: any) {
 export default function mappet<
   S extends Schema,
   O extends MappetOptions,
->(schema: S, options: Partial<O> = {}) {
+  >(schema: S, options: Partial<O> = {}) {
   const { strict, name = "Mappet", greedy } = options;
   return <T extends Source>(source: T) =>
     Object.keys(schema)
       .reduce((result, key) => {
         const schemaEntry = schema[key];
-        const include = typeof schemaEntry === "string" ? always : schemaEntry.include || always;
-        const path = typeof schemaEntry === "string" ? schemaEntry : schemaEntry.path;
+        const include = hasPathOnly(schemaEntry) ? always : (schemaEntry as ComplexSchemaEntry).include || always;
+        const path = hasPathOnly(schemaEntry) ? (schemaEntry as Path) : (schemaEntry as ComplexSchemaEntry).path;
         const value = get(source, path);
 
         if (!include(value, source)) {
           return result;
         }
 
-        const modifier = typeof schemaEntry === "string" ? identity : schemaEntry.modifier || identity;
+        const modifier = hasPathOnly(schemaEntry) ? identity : (schemaEntry as ComplexSchemaEntry).modifier || identity;
 
         if (strict && value === undefined) {
           throw new Error(`${name}: ${path} not found`);

--- a/src/mappet.ts
+++ b/src/mappet.ts
@@ -58,7 +58,7 @@ function always(_val: any) {
   return true;
 }
 
-function hasPathOnly(schemaEntry: SchemaEntry) {
+function hasPathOnly(schemaEntry: SchemaEntry): schemaEntry is Path {
   return typeof schemaEntry === "string" || Array.isArray(schemaEntry);
 }
 
@@ -78,15 +78,15 @@ export default function mappet<
     Object.keys(schema)
       .reduce((result, key) => {
         const schemaEntry = schema[key];
-        const include = hasPathOnly(schemaEntry) ? always : (schemaEntry as ComplexSchemaEntry).include || always;
-        const path = hasPathOnly(schemaEntry) ? (schemaEntry as Path) : (schemaEntry as ComplexSchemaEntry).path;
+        const include = hasPathOnly(schemaEntry) ? always : schemaEntry.include || always;
+        const path = hasPathOnly(schemaEntry) ? schemaEntry : schemaEntry.path;
         const value = get(source, path);
 
         if (!include(value, source)) {
           return result;
         }
 
-        const modifier = hasPathOnly(schemaEntry) ? identity : (schemaEntry as ComplexSchemaEntry).modifier || identity;
+        const modifier = hasPathOnly(schemaEntry) ? identity : schemaEntry.modifier || identity;
 
         if (strict && value === undefined) {
           throw new Error(`${name}: ${path} not found`);


### PR DESCRIPTION
Is it possible to let TypeScript know that
```javascript
hasPathOnly(schemaEntry) ? always : schemaEntry.include || always;
//                                        ^ here can be only ComplexSchemaEntry
```
?

Fixes #14.